### PR TITLE
Skip review if seen recently

### DIFF
--- a/lib/Auth/Process/ProfileReview.php
+++ b/lib/Auth/Process/ProfileReview.php
@@ -229,7 +229,6 @@ class sspmod_profilereview_Auth_Process_ProfileReview extends SimpleSAML_Auth_Pr
 
             unset($state['Attributes']['method']);
             unset($state['Attributes']['mfa']);
-            SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
             return;
         }
 

--- a/lib/Auth/Process/ProfileReview.php
+++ b/lib/Auth/Process/ProfileReview.php
@@ -238,6 +238,9 @@ class sspmod_profilereview_Auth_Process_ProfileReview extends SimpleSAML_Auth_Pr
         if (self::hasSeenSplashPageRecently()) {
             $log['event'] = 'skip review, seen recently';
             $this->logger->warning(json_encode($log));
+
+            unset($state['Attributes']['method']);
+            unset($state['Attributes']['mfa']);
             return;
         }
 

--- a/lib/Auth/Process/ProfileReview.php
+++ b/lib/Auth/Process/ProfileReview.php
@@ -307,5 +307,4 @@ class sspmod_profilereview_Auth_Process_ProfileReview extends SimpleSAML_Auth_Pr
         );
         $session->save();
     }
-
 }

--- a/www/review.php
+++ b/www/review.php
@@ -12,7 +12,8 @@ $state = SimpleSAML_Auth_State::loadState($stateId, ProfileReview::STAGE_SENT_TO
 $logger = LoggerFactory::getAccordingToState($state);
 
 /* Skip the splash page for awhile to avoid annoying them with constant warnings. */
-ProfileReview::skipSplashPagesFor(24 * 60 * 60);
+$oneDay = 24 * 60 * 60;
+ProfileReview::skipSplashPagesFor($oneDay);
 
 // If the user has pressed the set-up-Method button...
 if (filter_has_var(INPUT_POST, 'update')) {

--- a/www/review.php
+++ b/www/review.php
@@ -11,6 +11,9 @@ if (empty($stateId)) {
 $state = SimpleSAML_Auth_State::loadState($stateId, ProfileReview::STAGE_SENT_TO_NAG);
 $logger = LoggerFactory::getAccordingToState($state);
 
+/* Skip the splash page for awhile to avoid annoying them with constant warnings. */
+ProfileReview::skipSplashPagesFor(24 * 60 * 60);
+
 // If the user has pressed the set-up-Method button...
 if (filter_has_var(INPUT_POST, 'update')) {
     ProfileReview::redirectToProfile($state);


### PR DESCRIPTION
Changing the flag in the state didn't work, so this fix uses the session directly to prevent re-displaying the profile review too soon.