### PR TITLE
Correct which SimpleSAMLphp method we call to get the current session

### DIFF
--- a/lib/Auth/Process/ProfileReview.php
+++ b/lib/Auth/Process/ProfileReview.php
@@ -319,7 +319,7 @@ class ProfileReview extends ProcessingFilter
 
     public static function hasSeenSplashPageRecently(string $page)
     {
-        $session = Session::getSession();
+        $session = Session::getSessionFromRequest();
         return (bool)$session->getData(
             self::SESSION_TYPE,
             $page
@@ -328,7 +328,7 @@ class ProfileReview extends ProcessingFilter
 
     public static function skipSplashPagesFor($seconds, string $page)
     {
-        $session = Session::getSession();
+        $session = Session::getSessionFromRequest();
         $session->setData(
             self::SESSION_TYPE,
             $page,


### PR DESCRIPTION
### Fixed
- Correct which SimpleSAMLphp method we call to get the current session

---

For details, see [this GitHub issue/conversation](https://github.com/simplesamlphp/simplesamlphp/issues/1491)